### PR TITLE
Add limited support for collections in print jobs

### DIFF
--- a/src/pyipp/serializer.py
+++ b/src/pyipp/serializer.py
@@ -61,6 +61,40 @@ def construct_attribute(name: str, value: Any, tag: IppTag | None = None) -> byt
     return byte_str
 
 
+def encode_collection(name: str, collection: dict[str, Any]) -> bytes:
+    byte_str = b""
+
+    byte_str += struct.pack(">b", IppTag.BEGIN_COLLECTION.value)
+    byte_str += struct.pack(">h", len(name))
+    byte_str += name.encode("utf-8")
+    byte_str += struct.pack(">h", 0)
+
+    for name, value in collection.items():
+        if isinstance(value, dict):
+            byte_str += encode_collection(name=name, collection=value)
+        else:
+            byte_str += struct.pack(">b", IppTag.MEMBER_NAME.value)
+            byte_str += struct.pack(">h", 0)
+            byte_str += struct.pack(">h", len(name))
+            byte_str += name.encode("utf-8")
+            if isinstance(value, int):
+                byte_str += struct.pack(">b", IppTag.INTEGER.value)
+                byte_str += struct.pack(">h", 0)
+                byte_str += struct.pack(">h", 4)
+                byte_str += struct.pack(">h", value)
+            else:
+                byte_str += struct.pack(">b", IppTag.KEYWORD.value)
+                byte_str += struct.pack(">h", 0)
+                byte_str += struct.pack(">h", len(value))
+                byte_str += value.encode("utf-8")
+
+    byte_str += struct.pack(">b", IppTag.END_COLLECTION.value)
+    byte_str += struct.pack(">h", 0)
+    byte_str += struct.pack(">h", 0)
+
+    return byte_str
+
+
 def encode_dict(data: dict[str, Any]) -> bytes:
     """Serialize a dictionary of data into IPP format."""
     version = data["version"] or DEFAULT_PROTO_VERSION
@@ -83,7 +117,11 @@ def encode_dict(data: dict[str, Any]) -> bytes:
         encoded += struct.pack(">b", IppTag.JOB.value)
 
         for attr, value in data["job-attributes-tag"].items():
-            encoded += construct_attribute(attr, value)
+            encoded += (
+                encode_collection(attr, value)
+                if isinstance(value, dict)
+                else construct_attribute(attr, value)
+            )
 
     if isinstance(data.get("printer-attributes-tag", None), dict):
         encoded += struct.pack(">b", IppTag.PRINTER.value)
@@ -93,7 +131,7 @@ def encode_dict(data: dict[str, Any]) -> bytes:
 
     encoded += struct.pack(">b", IppTag.END.value)
 
-    if 'data' in data:
-        encoded += data['data']
+    if "data" in data:
+        encoded += data["data"]
 
     return encoded

--- a/src/pyipp/tags.py
+++ b/src/pyipp/tags.py
@@ -59,4 +59,12 @@ ATTRIBUTE_TAG_MAP = {
     "time-at-creation": IppTag.INTEGER,
     "time-at-processing": IppTag.INTEGER,
     "time-at-completed": IppTag.INTEGER,
+    "x-dimension": IppTag.INTEGER,
+    "y-dimension": IppTag.INTEGER,
+    "media-top-margin": IppTag.INTEGER,
+    "media-bottom-margin": IppTag.INTEGER,
+    "media-right-margin": IppTag.INTEGER,
+    "media-left-margin": IppTag.INTEGER,
+    "media-source": IppTag.KEYWORD,
+    "media-type": IppTag.KEYWORD,
 }


### PR DESCRIPTION
Adds limited support for collections in print jobs, which are necessary for some advanced tasks like selecting a tray to print from.

Only supports members of type `integer` or `keyword` right now, and only in jobs.